### PR TITLE
fix typo `Github` to `GitHub`

### DIFF
--- a/developer-guide/frontend/github-workflows.md
+++ b/developer-guide/frontend/github-workflows.md
@@ -1,5 +1,5 @@
 ---
-title: What do Github workflows do
+title: What do GitHub workflows do
 sidebar_position: 7
 ---
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -148,7 +148,7 @@ const lightCodeTheme = require("prism-react-renderer/themes/github");
               title: "Community",
               items: [
                 {
-                  label: "Github",
+                  label: "GitHub",
                   href: "https://github.com/reearth/reearth",
                 },
                 {

--- a/i18n/ja/docusaurus-plugin-content-docs-tutorial/current/create-3d-models-for-reearth/3d-model-for-reearth/gltf-format.md
+++ b/i18n/ja/docusaurus-plugin-content-docs-tutorial/current/create-3d-models-for-reearth/3d-model-for-reearth/gltf-format.md
@@ -12,7 +12,7 @@ Today, we have many introductions about the glTF file everywhere, and here I jus
 
 ### Open-source
 
-The GL Transmission Format ( glTF for short ) is an open-source format that was released to the public in October 2015 by members of the COLLADA working group. You can check all the details on the Github page [here](https://github.com/KhronosGroup/glTF). It is also because of open-source that many platforms support this format quite well. Large companies like Google, Microsoft are trying to embed glTF formate into their environment. Other open-source communities like three.js use glTF as the main 3D files. Cesium also supports glTF at the beginning.
+The GL Transmission Format ( glTF for short ) is an open-source format that was released to the public in October 2015 by members of the COLLADA working group. You can check all the details on the GitHub page [here](https://github.com/KhronosGroup/glTF). It is also because of open-source that many platforms support this format quite well. Large companies like Google, Microsoft are trying to embed glTF formate into their environment. Other open-source communities like three.js use glTF as the main 3D files. Cesium also supports glTF at the beginning.
 
 ### Design for web
 

--- a/i18n/ja/docusaurus-plugin-content-docs-user-manual/current/project-and-workspace/project/plugin-library.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs-user-manual/current/project-and-workspace/project/plugin-library.mdx
@@ -21,7 +21,7 @@ sidebar_position: 6
     <strong>PCからZipファイルをアップロード</strong> ボタンでは、自身のPCからzipファイルを選択してプラグインをインストールします。
   </List>
   <List>
-    <strong>Githubパブリックレポジトリ</strong> ボタンでは、Githubから直接プラグインをインストールします。
+    <strong>GitHubパブリックレポジトリ</strong> ボタンでは、GitHubから直接プラグインをインストールします。
   </List>
   詳しい手順は「プラグインのインストール」をご覧ください。
   <List>

--- a/i18n/ja/docusaurus-theme-classic/footer.json
+++ b/i18n/ja/docusaurus-theme-classic/footer.json
@@ -59,9 +59,9 @@
     "message": "Tutorials",
     "description": "The label of footer link with label=Tutorials linking to /tutorial/index"
   },
-  "link.item.label.Github": {
-    "message": "Github",
-    "description": "The label of footer link with label=Github linking to https://github.com/reearth/reearth"
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/reearth/reearth"
   },
   "link.item.label.Code of conduct": {
     "message": "Code of conduct",

--- a/tutorial/create-3d-models-for-reearth/3d-model-for-reearth/gltf-format.md
+++ b/tutorial/create-3d-models-for-reearth/3d-model-for-reearth/gltf-format.md
@@ -12,7 +12,7 @@ Today, we have many introductions about the glTF file everywhere, and here I jus
 
 ### Open-source
 
-The GL Transmission Format ( glTF for short ) is an open-source format that was released to the public in October 2015 by members of the COLLADA working group. You can check all the details on the Github page [here](https://github.com/KhronosGroup/glTF). It is also because of open-source that many platforms support this format quite well. Large companies like Google, Microsoft are trying to embed glTF formate into their environment. Other open-source communities like three.js use glTF as the main 3D files. Cesium also supports glTF at the beginning.
+The GL Transmission Format ( glTF for short ) is an open-source format that was released to the public in October 2015 by members of the COLLADA working group. You can check all the details on the GitHub page [here](https://github.com/KhronosGroup/glTF). It is also because of open-source that many platforms support this format quite well. Large companies like Google, Microsoft are trying to embed glTF formate into their environment. Other open-source communities like three.js use glTF as the main 3D files. Cesium also supports glTF at the beginning.
 
 ### Design for web
 

--- a/user-manual/project-and-workspace/project/plugin-library.mdx
+++ b/user-manual/project-and-workspace/project/plugin-library.mdx
@@ -17,7 +17,7 @@ The Plugin library page is used to install, remove and manage plugins.
     <strong>Zip file from PC</strong> button allows you to install the plugin from your computer.
   </List>
   <List>
-    <strong>Public Github Repository</strong> button allows you to install the plugin directly from Github.
+    <strong>Public GitHub Repository</strong> button allows you to install the plugin directly from GitHub.
   </List>
   Please see [Installing a plugin] for the detailed process.
   <List>


### PR DESCRIPTION
## WHY

To fix the company and the product name to the correct spelling.

[GitHub](https://en.wikipedia.org/wiki/GitHub) has large `H` not small `h`. This PR intends to correct these misspellings.